### PR TITLE
Update discoverdisks.ps1 define arrays

### DIFF
--- a/discoverdisks.ps1
+++ b/discoverdisks.ps1
@@ -1,4 +1,5 @@
-$drives = Get-WmiObject win32_PerfFormattedData_PerfDisk_PhysicalDisk | 
+$drives = @{}
+$drives += Get-WmiObject win32_PerfFormattedData_PerfDisk_PhysicalDisk | 
     ?{$_.name -ne "_Total"} |  
     select Name;
 


### PR DESCRIPTION
will not work with 1 disk in array is not defined, will assume it's a string